### PR TITLE
Added calendar previews to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,56 @@
-# Calendar for 2020 :)
+# Linux and Developer-themed Calendars for 2020 :)
 
-Artworks are form linux.pictures and everything is made using inkscape.
+Linux logo artwork sourced from **linux.pictures** _(website no longer available)_. Calendars were made using [Inkscape](https://inkscape.org/).
+
+## Arch
+
+<img src="arch.png" width="300">
+
+<img src="arch_2.png" width="300">
+
+## BSD
+
+<img src="bsd.png" width="300">
+
+## Debian
+
+<img src="debian.png" width="300">
+
+<img src="debian_2.png" width="300">
+
+## Fedora
+
+<img src="fedora.png" width="300">
+
+<img src="fedora_2.png" width="300">
+
+## GCC
+
+<img src="gcc.png" width="300">
+
+## GNU
+
+<img src="gnu_linux.png" width="300">
+
+## Linux Kernel
+
+<img src="linux_kernel.png" width="300">
+
+
+## Manjaro
+
+<img src="manjaro.png" width="300">
+
+
+## Mint
+
+<img src="mint.png" width="300">
+
+
+## Python
+
+<img src="python.png" width="300">
+
+## Ubuntu
+
+<img src="ubuntu.png" width="300">


### PR DESCRIPTION
This PR implements https://github.com/nk521/2020_linux_calendar/issues/6

This change adds small preview images of each of the calendars. Clicking on the images takes you to the image itself so you can download it.

_( Happy Hacktoberfest :jack_o_lantern: :bat: )_